### PR TITLE
DoubleRange implementation

### DIFF
--- a/src/main/java/com/github/javachat/doublerange/DoubleCut.java
+++ b/src/main/java/com/github/javachat/doublerange/DoubleCut.java
@@ -1,0 +1,42 @@
+package com.github.javachat.doublerange;
+
+import com.github.javachat.common.BoundType;
+
+/**
+ * Helper class {@link DoubleRange} to represent a combination of value and boundary type.
+ * <p>
+ * This class is used in cases where a boundary value and type from two ranges can be chosen.
+ */
+class DoubleCut {
+    private double value;
+    private BoundType boundType;
+
+    DoubleCut(double value, BoundType boundType) {
+        this.value = value;
+        this.boundType = boundType;
+    }
+
+    double getValue() {
+        return value;
+    }
+
+    BoundType getBoundType() {
+        return boundType;
+    }
+
+    static DoubleCut open(double value) {
+        return new DoubleCut(value, BoundType.OPEN);
+    }
+
+    static DoubleCut closed(double value) {
+        return new DoubleCut(value, BoundType.CLOSED);
+    }
+
+    static DoubleCut min(DoubleCut first, DoubleCut second) {
+        return (first.value <= second.value) ? first : second;
+    }
+
+    static DoubleCut max(DoubleCut first, DoubleCut second) {
+        return (first.value >= second.value) ? first : second;
+    }
+}

--- a/src/main/java/com/github/javachat/doublerange/DoubleRange.java
+++ b/src/main/java/com/github/javachat/doublerange/DoubleRange.java
@@ -1,0 +1,378 @@
+package com.github.javachat.doublerange;
+
+import com.github.javachat.common.BoundType;
+
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.text.NumberFormat;
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.function.DoublePredicate;
+
+/**
+ * A range of double values.
+ * <p>
+ * This is meant as a drop-in replacement for
+ * <a href="http://google.github.io/guava/releases/19.0/api/docs/com/google/common/collect/Range.html">Range&lt;Double&gt;</a>,
+ * therefore the semantics of the Guava class apply to this class as well.
+ * <p>
+ * In regard to double specifics, this implementation follows Java semantics, this means:
+ * <p>
+ * <ul>
+ * <li>Any double lies between +Infinity and -Infinity</li>
+ * <li>NaN always lies in an all range</li>
+ * <li>NaN never lies in a range with discrete boundaries</li>
+ * </ul>
+ */
+public class DoubleRange {
+    /**
+     * The all range that spans every double value (but not {@link Double#NaN})
+     */
+    static final DoubleRange INFINITE_RANGE = new DoubleRange(Double.NEGATIVE_INFINITY, BoundType.OPEN,
+            Double.POSITIVE_INFINITY, BoundType.OPEN);
+
+    // Exception messages
+    static final String ILLEGAL_BOUND = "lower bound %.5f must be less than or equal " +
+            "to upper bound %.5f";
+    static final String ILLEGAL_OPEN_RANGE = "when specifying an open range, "
+            + "the lower bound must be strictly less than the upper bound";
+    static final String BOUNDARY_IS_NAN = "No boundary can be NaN";
+    static final String NO_CONNECTION = "Cannot create intersection from two unconnected ranges (%s and %s)";
+
+    // Formatting specifics
+    static final DecimalFormatSymbols TO_STRING_FORMAT_SYMBOLS;
+    static final NumberFormat TO_STRING_FORMAT;
+
+    static {
+        // Better to have consistent formatting symbols.
+        TO_STRING_FORMAT_SYMBOLS = DecimalFormatSymbols.getInstance(Locale.US);
+        TO_STRING_FORMAT_SYMBOLS.setInfinity("Infinity");
+        TO_STRING_FORMAT = new DecimalFormat("#0.0#####", TO_STRING_FORMAT_SYMBOLS);
+    }
+
+    private final BoundType lowerBoundType;
+    private final BoundType upperBoundType;
+    private final double lowerBound;
+    private final double upperBound;
+    private final DoublePredicate lowerCheck;
+    private final DoublePredicate upperCheck;
+
+    /**
+     * @see <a href="http://google.github.io/guava/releases/19.0/api/docs/com/google/common/collect/Range.html#open(C, C)">Guava JavaDoc</a>
+     */
+    public static DoubleRange open(double lowerBound, double upperBound) {
+        return new DoubleRange(lowerBound, BoundType.OPEN, upperBound, BoundType.OPEN);
+    }
+
+    /**
+     * @see <a href="http://google.github.io/guava/releases/19.0/api/docs/com/google/common/collect/Range.html#closed(C, C)">Guava JavaDoc</a>
+     */
+    public static DoubleRange closed(double lowerBound, double upperBound) {
+        return new DoubleRange(lowerBound, BoundType.CLOSED, upperBound, BoundType.CLOSED);
+    }
+
+    /**
+     * @see <a href="http://google.github.io/guava/releases/19.0/api/docs/com/google/common/collect/Range.html#closedOpen(C, C)">Guava JavaDoc</a>
+     */
+    public static DoubleRange closedOpen(double lowerBound, double upperBound) {
+        return new DoubleRange(lowerBound, BoundType.CLOSED, upperBound, BoundType.OPEN);
+    }
+
+    /**
+     * @see <a href="http://google.github.io/guava/releases/19.0/api/docs/com/google/common/collect/Range.html#openClosed(C, C)">Guava JavaDoc</a>
+     */
+    public static DoubleRange openClosed(double lowerBound, double upperBound) {
+        return new DoubleRange(lowerBound, BoundType.OPEN, upperBound, BoundType.CLOSED);
+    }
+
+    /**
+     * @see <a href="http://google.github.io/guava/releases/19.0/api/docs/com/google/common/collect/Range.html#range(C, com.google.common.collect.BoundType, C, com.google.common.collect.BoundType)">Guava JavaDoc</a>
+     */
+    public static DoubleRange range(double lowerBound, BoundType lowerBoundType, double upperBound, BoundType upperBoundType) {
+        return new DoubleRange(lowerBound, lowerBoundType, upperBound, upperBoundType);
+    }
+
+
+    /**
+     * @see <a href="http://google.github.io/guava/releases/19.0/api/docs/com/google/common/collect/Range.html#lessThan(C)">Guava JavaDoc</a>
+     */
+    public static DoubleRange lessThan(double endpoint) {
+        return upTo(endpoint, BoundType.CLOSED);
+    }
+
+
+    /**
+     * @see <a href="http://google.github.io/guava/releases/19.0/api/docs/com/google/common/collect/Range.html#atMost(C)">Guava JavaDoc</a>
+     */
+    public static DoubleRange atMost(double endpoint) {
+        return upTo(endpoint, BoundType.OPEN);
+    }
+
+
+    /**
+     * @see <a href="http://google.github.io/guava/releases/19.0/api/docs/com/google/common/collect/Range.html#upTo(C, com.google.common.collect.BoundType)">Guava JavaDoc</a>
+     */
+    public static DoubleRange upTo(double endpoint, BoundType boundType) {
+        return range(Double.NEGATIVE_INFINITY, BoundType.OPEN, endpoint, boundType);
+    }
+
+
+    /**
+     * @see <a href="http://google.github.io/guava/releases/19.0/api/docs/com/google/common/collect/Range.html#greaterThan(C)">Guava JavaDoc</a>
+     */
+    public static DoubleRange greaterThan(double endpoint) {
+        return downTo(endpoint, BoundType.CLOSED);
+    }
+
+
+    /**
+     * @see <a href="http://google.github.io/guava/releases/19.0/api/docs/com/google/common/collect/Range.html#atLeast(C)">Guava JavaDoc</a>
+     */
+    public static DoubleRange atLeast(double endpoint) {
+        return downTo(endpoint, BoundType.OPEN);
+    }
+
+
+    /**
+     * @see <a href="http://google.github.io/guava/releases/19.0/api/docs/com/google/common/collect/Range.html#downTo(C, com.google.common.collect.BoundType)">Guava JavaDoc</a>
+     */
+    public static DoubleRange downTo(double endpoint, BoundType boundType) {
+        return range(endpoint, boundType, Double.POSITIVE_INFINITY, BoundType.OPEN);
+    }
+
+    /**
+     * @see <a href="http://google.github.io/guava/releases/19.0/api/docs/com/google/common/collect/Range.html#singleton(C)">Guava JavaDoc</a>
+     */
+    public static DoubleRange singleton(double value) {
+        return DoubleRange.closed(value, value);
+    }
+
+    /**
+     * @see <a href="http://google.github.io/guava/releases/19.0/api/docs/com/google/common/collect/Range.html#encloseAll(java.lang.Iterable)">Guava JavaDoc</a>
+     */
+    public static DoubleRange encloseAll(double... values) {
+        if (values.length == 0) {
+            throw new NoSuchElementException("Given array is empty");
+        }
+
+        // Create a sorted copy and use the first and last element.
+        double[] copy = Arrays.copyOf(values, values.length);
+        Arrays.sort(copy);
+        return DoubleRange.closed(copy[0], copy[copy.length - 1]);
+    }
+
+     /**
+     * @see <a href="http://google.github.io/guava/releases/19.0/api/docs/com/google/common/collect/Range.html#all()">Guava JavaDoc</a>
+     */
+    public static DoubleRange all() {
+        return INFINITE_RANGE;
+    }
+
+    DoubleRange(double lowerBound, BoundType lowerBoundType, double upperBound, BoundType upperBoundType) {
+        if (Double.isNaN(lowerBound) || Double.isNaN(upperBound)) {
+            throw new IllegalArgumentException(BOUNDARY_IS_NAN);
+        }
+
+        if (Double.compare(lowerBound, upperBound) > 0) {
+            throw new IllegalArgumentException(String.format(ILLEGAL_BOUND, lowerBound, upperBound));
+        }
+
+        if (lowerBound == upperBound
+                && lowerBoundType == BoundType.OPEN
+                && lowerBoundType == upperBoundType) {
+            throw new IllegalArgumentException(ILLEGAL_OPEN_RANGE);
+        }
+
+        this.lowerBound = lowerBound;
+        this.upperBound = upperBound;
+        this.lowerBoundType = lowerBoundType;
+        this.upperBoundType = upperBoundType;
+
+        if (Double.isInfinite(lowerBound)) {
+            lowerCheck = value -> true;
+        } else {
+            lowerCheck = (lowerBoundType == BoundType.OPEN)
+                    ? value -> value >= lowerBound
+                    : value -> value > lowerBound;
+        }
+
+        if (Double.isInfinite(upperBound)) {
+            upperCheck = value -> true;
+        } else {
+            upperCheck = (upperBoundType == BoundType.OPEN)
+                    ? value -> value <= upperBound
+                    : value -> value < upperBound;
+        }
+    }
+
+    private DoubleRange(DoubleCut lower, DoubleCut upper) {
+        this(lower.getValue(), lower.getBoundType(), upper.getValue(), upper.getBoundType());
+    }
+
+    /**
+     * @see <a href="http://google.github.io/guava/releases/19.0/api/docs/com/google/common/collect/Range.html#hasLowerBound()">Guava JavaDoc</a>
+     */
+    public boolean hasLowerBound() {
+        return Double.isFinite(lowerBound);
+    }
+
+
+    /**
+     * @see <a href="http://google.github.io/guava/releases/19.0/api/docs/com/google/common/collect/Range.html#lowerEndpoint()">Guava JavaDoc</a>
+     */
+    public double lowerEndpoint() {
+        return lowerBound;
+    }
+
+
+    /**
+     * @see <a href="http://google.github.io/guava/releases/19.0/api/docs/com/google/common/collect/Range.html#lowerBoundType()">Guava JavaDoc</a>
+     */
+    public BoundType lowerBoundType() {
+        return lowerBoundType;
+    }
+
+
+    /**
+     * @see <a href="http://google.github.io/guava/releases/19.0/api/docs/com/google/common/collect/Range.html#hasUpperBound()">Guava JavaDoc</a>
+     */
+    public boolean hasUpperBound() {
+        return Double.isFinite(upperBound);
+    }
+
+
+    /**
+     * @see <a href="http://google.github.io/guava/releases/19.0/api/docs/com/google/common/collect/Range.html#upperEndpoint()">Guava JavaDoc</a>
+     */
+    public double upperEndpoint() {
+        return upperBound;
+    }
+
+
+    /**
+     * @see <a href="http://google.github.io/guava/releases/19.0/api/docs/com/google/common/collect/Range.html#upperBoundType()">Guava JavaDoc</a>
+     */
+    public BoundType upperBoundType() {
+        return upperBoundType;
+    }
+
+
+    /**
+     * @see <a href="http://google.github.io/guava/releases/19.0/api/docs/com/google/common/collect/Range.html#isEmpty()">Guava JavaDoc</a>
+     */
+    public boolean isEmpty() {
+        return lowerBound == upperBound;
+    }
+
+    /**
+     * @see <a href="http://google.github.io/guava/releases/19.0/api/docs/com/google/common/collect/Range.html#contains(C)">Guava JavaDoc</a>
+     */
+    public boolean contains(double value) {
+        return lowerCheck.test(value) && upperCheck.test(value);
+    }
+
+
+    /**
+     * @see <a href="http://google.github.io/guava/releases/19.0/api/docs/com/google/common/collect/Range.html#containsAll(java.lang.Iterable)">Guava JavaDoc</a>
+     */
+    public boolean containsAll(double... values) {
+        return Arrays.stream(values)
+                .allMatch(this::contains);
+    }
+
+
+    /**
+     * @see <a href="http://google.github.io/guava/releases/19.0/api/docs/com/google/common/collect/Range.html#encloses(com.google.common.collect.Range)">Guava JavaDoc</a>
+     */
+    public boolean encloses(DoubleRange other) {
+        return equals(other) // Enclosure is reflexive.
+                || (lowerCheck.test(other.lowerBound)
+                && lowerCheck.test(other.upperBound)
+                && upperCheck.test(other.lowerBound)
+                && upperCheck.test(other.upperBound));
+    }
+
+
+    /**
+     * @see <a href="http://google.github.io/guava/releases/19.0/api/docs/com/google/common/collect/Range.html#isConnected(com.google.common.collect.Range)">Guava JavaDoc</a>
+     */
+    public boolean isConnected(DoubleRange other) {
+        return (this.lowerCheck.test(other.upperBound) && this.upperCheck.test(other.upperBound))
+                || (this.upperCheck.test(other.lowerBound) && this.lowerCheck.test(other.lowerBound));
+    }
+
+
+    /**
+     * @see <a href="http://google.github.io/guava/releases/19.0/api/docs/com/google/common/collect/Range.html#intersection(com.google.common.collect.Range)">Guava JavaDoc</a>
+     */
+    public DoubleRange intersection(DoubleRange other) {
+        if (!this.isConnected(other)) {
+            throw new IllegalArgumentException(String.format(NO_CONNECTION, this, other));
+        }
+
+        return new DoubleRange(
+                DoubleCut.max(this.toLowerCut(), other.toLowerCut()),
+                DoubleCut.min(this.toUpperCut(), other.toUpperCut())
+        );
+    }
+
+
+    /**
+     * @see <a href="http://google.github.io/guava/releases/19.0/api/docs/com/google/common/collect/Range.html#span(com.google.common.collect.Range)">Guava JavaDoc</a>
+     */
+    public DoubleRange span(DoubleRange other) {
+        return new DoubleRange(
+                DoubleCut.min(this.toLowerCut(), other.toLowerCut()),
+                DoubleCut.max(this.toUpperCut(), other.toUpperCut())
+        );
+    }
+
+    private DoubleCut toLowerCut() {
+        return new DoubleCut(lowerBound, lowerBoundType);
+    }
+
+    private DoubleCut toUpperCut() {
+        return new DoubleCut(upperBound, upperBoundType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(lowerBound, lowerBoundType, upperBound, upperBoundType);
+    }
+
+
+    /**
+     * @see <a href="http://google.github.io/guava/releases/19.0/api/docs/com/google/common/collect/Range.html#eqauals()">Guava JavaDoc</a>
+     */
+    @SuppressWarnings("OverlyComplexBooleanExpression")
+    @Override
+    public boolean equals(final Object obj) {
+        if (this == obj)
+            return true;
+        if (!(obj instanceof DoubleRange)) // also takes care of obj == null
+            return false;
+        final DoubleRange other = (DoubleRange) obj;
+        return lowerBound == other.lowerBound
+                && upperBound == other.upperBound
+                && lowerBoundType == other.lowerBoundType
+                && upperBoundType == other.upperBoundType;
+    }
+
+
+    /**
+     * @see <a href="http://google.github.io/guava/releases/19.0/api/docs/com/google/common/collect/Range.html#toString()">Guava JavaDoc</a>
+     */
+    @Override
+    public String toString() {
+        @SuppressWarnings("StringBufferReplaceableByString")
+        final StringBuilder sb = new StringBuilder();
+
+        sb.append(lowerBoundType == BoundType.CLOSED ? "[" : "(");
+        sb.append(TO_STRING_FORMAT.format(lowerBound)).append("..").append(TO_STRING_FORMAT.format(upperBound));
+        sb.append(upperBoundType == BoundType.CLOSED ? "]" : ")");
+
+        return sb.toString();
+    }
+}

--- a/src/test/java/com/github/javachat/doublerange/DoubleRangeBoundTest.java
+++ b/src/test/java/com/github/javachat/doublerange/DoubleRangeBoundTest.java
@@ -1,0 +1,19 @@
+package com.github.javachat.doublerange;
+
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DoubleRangeBoundTest {
+    @Test
+    public void testFiniteBounds() {
+        assertThat(DoubleRange.closed(1, 3).hasLowerBound()).isTrue();
+        assertThat(DoubleRange.closed(1, 3).hasUpperBound()).isTrue();
+    }
+
+    @Test
+    public void testInfiniteBounds() {
+        assertThat(DoubleRange.all().hasLowerBound()).isFalse();
+        assertThat(DoubleRange.all().hasUpperBound()).isFalse();
+    }
+}

--- a/src/test/java/com/github/javachat/doublerange/DoubleRangeBuildTest.java
+++ b/src/test/java/com/github/javachat/doublerange/DoubleRangeBuildTest.java
@@ -1,0 +1,71 @@
+package com.github.javachat.doublerange;
+
+import com.github.javachat.common.BoundType;
+import org.testng.annotations.Test;
+
+import java.util.NoSuchElementException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.shouldHaveThrown;
+
+public class DoubleRangeBuildTest {
+    @Test
+    public void testIllegalBounds() {
+        try {
+            new DoubleRange(3.0, BoundType.CLOSED, 2.0, BoundType.CLOSED);
+            shouldHaveThrown(IllegalArgumentException.class);
+        } catch (IllegalArgumentException e) {
+            final String msg = String.format(DoubleRange.ILLEGAL_BOUND, 3.0, 2.0);
+            assertThat(e).hasMessage(msg);
+        }
+    }
+
+    @Test
+    public void testIllegalOpenRange() {
+        try {
+            new DoubleRange(3, BoundType.OPEN, 3, BoundType.OPEN);
+            shouldHaveThrown(IllegalArgumentException.class);
+        } catch (IllegalArgumentException e) {
+            assertThat(e).hasMessage(DoubleRange.ILLEGAL_OPEN_RANGE);
+        }
+    }
+
+    @Test
+    public void testNotANumber() {
+        try {
+            new DoubleRange(Double.NaN, BoundType.OPEN, 3, BoundType.OPEN);
+            shouldHaveThrown(IllegalArgumentException.class);
+        } catch (IllegalArgumentException e) {
+            assertThat(e).hasMessage(DoubleRange.BOUNDARY_IS_NAN);
+        }
+
+        try {
+            new DoubleRange(2, BoundType.OPEN, Double.NaN, BoundType.OPEN);
+            shouldHaveThrown(IllegalArgumentException.class);
+        } catch (IllegalArgumentException e) {
+            assertThat(e).hasMessage(DoubleRange.BOUNDARY_IS_NAN);
+        }
+    }
+
+    @Test
+    public void testIllegalInfinities() {
+        try {
+            new DoubleRange(Double.POSITIVE_INFINITY, BoundType.OPEN, Double.NEGATIVE_INFINITY, BoundType.OPEN);
+            shouldHaveThrown(IllegalArgumentException.class);
+        } catch (IllegalArgumentException e) {
+            final String msg = String.format(DoubleRange.ILLEGAL_BOUND, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY);
+            assertThat(e).hasMessage(msg);
+        }
+    }
+
+    @Test
+    public void testEncloseAllFactoryMethod() {
+        DoubleRange range = DoubleRange.encloseAll(-1, 0, 1);
+        assertThat(range).isEqualTo(DoubleRange.closed(-1, 1));
+    }
+
+    @Test(expectedExceptions = NoSuchElementException.class)
+    public void testEncloseAllFactoryMethodEmptyArray() {
+        DoubleRange.encloseAll();
+    }
+}

--- a/src/test/java/com/github/javachat/doublerange/DoubleRangeConnectednessTest.java
+++ b/src/test/java/com/github/javachat/doublerange/DoubleRangeConnectednessTest.java
@@ -1,0 +1,45 @@
+package com.github.javachat.doublerange;
+
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DoubleRangeConnectednessTest {
+
+    public static final String CONNECTION_DESC = "%s is connected to %s (both contain %s)";
+
+    @Test
+    public void testSimpleNonConnectedness() {
+        DoubleRange lower = DoubleRange.openClosed(2, 4);
+        DoubleRange higher = DoubleRange.openClosed(5, 7);
+
+        assertThat(lower.isConnected(higher)).as("Unrelated ranges %s, %s should not be connected", lower, higher)
+                .isFalse();
+    }
+
+    @Test
+    public void testSimpleConnection() {
+        DoubleRange lower = DoubleRange.closedOpen(2, 4);
+        DoubleRange higher = DoubleRange.closedOpen(3, 6);
+
+        assertThat(lower.isConnected(higher)).as(CONNECTION_DESC, lower, higher, DoubleRange.closedOpen(3, 4)).isTrue();
+    }
+
+    @Test
+    public void testConnectionThroughEmptyRange() {
+        DoubleRange lower = DoubleRange.closedOpen(2, 4);
+        DoubleRange higher = DoubleRange.closedOpen(4, 6);
+
+        assertThat(lower.isConnected(higher)).as(CONNECTION_DESC, lower, higher, DoubleRange.closedOpen(4, 4)).isTrue();
+    }
+
+    @Test
+    public void testConnectedInfinity() {
+        DoubleRange infinite = DoubleRange.all();
+        DoubleRange finite = DoubleRange.closedOpen(2, 4);
+
+        assertThat(infinite.isConnected(finite))
+                .as("%s and %s should be connected, %s is enclosed by both", infinite, finite, finite)
+                .isTrue();
+    }
+}

--- a/src/test/java/com/github/javachat/doublerange/DoubleRangeContainsTest.java
+++ b/src/test/java/com/github/javachat/doublerange/DoubleRangeContainsTest.java
@@ -1,0 +1,74 @@
+package com.github.javachat.doublerange;
+
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DoubleRangeContainsTest {
+
+    @Test
+    public void testClosedRangeTest() {
+        DoubleRange range = DoubleRange.closed(1, 2);
+
+        assertThat(range.contains(1.0)).isFalse();
+        assertThat(range.contains(Math.nextUp(1.0))).isTrue();
+
+        assertThat(range.contains(Math.nextDown(2.0))).isTrue();
+        assertThat(range.contains(2.0)).isFalse();
+    }
+
+    @Test
+    public void testOpenRangeTest() {
+        DoubleRange range = DoubleRange.open(1, 2);
+
+        assertThat(range.contains(Math.nextDown(1.0))).isFalse();
+        assertThat(range.contains(1.0)).isTrue();
+        assertThat(range.contains(Math.nextUp(1.0))).isTrue();
+
+        assertThat(range.contains(Math.nextDown(2.0))).isTrue();
+        assertThat(range.contains(2.0)).isTrue();
+        assertThat(range.contains(Math.nextUp(2.0))).isFalse();
+    }
+
+    @Test
+    public void testInfinity() {
+        DoubleRange range = DoubleRange.all();
+
+        assertThat(range.contains(Double.MIN_VALUE));
+        assertThat(range.contains(-Double.MIN_VALUE));
+        assertThat(range.contains(-Double.MAX_VALUE));
+        assertThat(range.contains(-1.0)).isTrue();
+        assertThat(range.contains(0.0)).isTrue();
+        assertThat(range.contains(1.0)).isTrue();
+        assertThat(range.contains(Double.MAX_VALUE));
+        assertThat(range.contains(Double.POSITIVE_INFINITY)).isTrue();
+        assertThat(range.contains(Double.NEGATIVE_INFINITY)).isTrue();
+    }
+
+    @Test
+    public void testSemiDiscreteRange() {
+        DoubleRange range = DoubleRange.greaterThan(1.0);
+
+        assertThat(range.contains(1.0)).isFalse();
+        assertThat(range.contains(Math.nextUp(1.0))).isTrue();
+        assertThat(range.contains(Double.MAX_VALUE));
+    }
+
+    @Test
+    public void testNaNHandling() {
+        DoubleRange infiniteRange = DoubleRange.all();
+        assertThat(infiniteRange.contains(Double.NaN)).as("NaN is part of the infinite range").isTrue();
+
+        DoubleRange discreteRange = DoubleRange.open(1, 2);
+        assertThat(discreteRange.contains(Double.NaN)).as("NaN is not part of a discrete range").isFalse();
+    }
+
+    @Test
+    public void testContainsAll() {
+        DoubleRange range = DoubleRange.openClosed(3, 6);
+
+        assertThat(range.containsAll(3, Math.nextUp(3), Math.nextDown(6))).isTrue();
+        assertThat(range.containsAll(3, 6)).isFalse();
+        assertThat(range.containsAll(3, Double.NaN)).isFalse();
+    }
+}

--- a/src/test/java/com/github/javachat/doublerange/DoubleRangeEmptinessTest.java
+++ b/src/test/java/com/github/javachat/doublerange/DoubleRangeEmptinessTest.java
@@ -1,0 +1,36 @@
+package com.github.javachat.doublerange;
+
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DoubleRangeEmptinessTest {
+    @Test
+    public void testFiniteNonEmptyRange() {
+        DoubleRange range = DoubleRange.closed(3, 6);
+        assertThat(range.isEmpty()).as("%s should not be empty").isFalse();
+    }
+
+    @Test
+    public void testInfiniteRange() {
+        DoubleRange range = DoubleRange.all();
+        assertThat(range.isEmpty()).as("Infinite range should not be empty").isFalse();
+    }
+
+    @Test
+    public void testFiniteClosedEmptyRange() {
+        DoubleRange range = DoubleRange.closed(4.0, 4.0);
+        String description = "%s should be empty (closed range does not contain boundary elements)";
+        assertThat(range.isEmpty()).as(description, range).isTrue();
+    }
+
+    @Test
+    public void testFiniteEmptyRanges() {
+        String description = "%s should be empty (contains no elements since no elements lie between 4.0 and 4.0)";
+        DoubleRange closedOpen = DoubleRange.closedOpen(4.0, 4.0);
+        DoubleRange openClosed = DoubleRange.openClosed(4.0, 4.0);
+
+        assertThat(closedOpen.isEmpty()).as(description, closedOpen).isTrue();
+        assertThat(openClosed.isEmpty()).as(description, openClosed).isTrue();
+    }
+}

--- a/src/test/java/com/github/javachat/doublerange/DoubleRangeEnclosesTest.java
+++ b/src/test/java/com/github/javachat/doublerange/DoubleRangeEnclosesTest.java
@@ -1,0 +1,76 @@
+package com.github.javachat.doublerange;
+
+import com.github.javachat.common.BoundType;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DoubleRangeEnclosesTest {
+    private static final String ENCLOSURE_DESC = "%s should enclose %s";
+    private static final String SELF_ENCLOSURE_DESC = "%s should enclose itself";
+
+    @Test
+    public void testSimpleEnclosure() {
+        DoubleRange outer = new DoubleRange(0.0, BoundType.OPEN, 10.0, BoundType.OPEN);
+        DoubleRange inner = new DoubleRange(4.0, BoundType.OPEN, 6.0, BoundType.OPEN);
+
+        assertThat(outer.encloses(inner)).as(ENCLOSURE_DESC, outer, inner).isTrue();
+    }
+
+    @Test
+    public void testSimpleNonEnclosure() {
+        DoubleRange lower = DoubleRange.open(0, 9);
+        DoubleRange higher = DoubleRange.open(10, 20);
+
+        assertThat(lower.encloses(higher)).as("%s should not enclose unrelated %s", lower, higher).isFalse();
+    }
+
+    @Test
+    public void testOpenRangeEnclosesSelf() {
+        DoubleRange one = DoubleRange.open(0, 9);
+        DoubleRange two = DoubleRange.open(0, 9);
+
+        assertThat(one.encloses(two)).as(SELF_ENCLOSURE_DESC, one).isTrue();
+    }
+
+    @Test
+    public void testOpenClosedRangeEnclosesSelf() {
+        DoubleRange one = DoubleRange.openClosed(0, 9);
+        DoubleRange two = DoubleRange.openClosed(0, 9);
+
+        assertThat(one.encloses(two)).as(SELF_ENCLOSURE_DESC, one).isTrue();
+    }
+
+    @Test
+    public void testClosedDoesNotEncloseOpenCounterpart() {
+        DoubleRange closed = DoubleRange.closed(0, 9);
+        DoubleRange open = DoubleRange.open(0, 9);
+
+        assertThat(closed.encloses(open)).as("%s should not enclose open counterpart %s", closed, open).isFalse();
+    }
+
+    @Test
+    public void testOpenBoundaryDoesNotEncloseClosedBoundary() {
+        DoubleRange withOpenBoundary = DoubleRange.openClosed(3, 6);
+        DoubleRange withClosedBoundary = DoubleRange.closed(3, 6);
+
+        assertThat(withOpenBoundary.encloses(withClosedBoundary)).as("%s should not contain %s").isFalse();
+    }
+
+    @Test
+    public void testInnerRangeDoesNotEncloseOuter() {
+        DoubleRange inner = DoubleRange.closed(4, 5);
+        DoubleRange outer = DoubleRange.open(3, 6);
+
+        assertThat(inner.encloses(outer)).isFalse();
+    }
+
+    @Test
+    public void testInfinityEnclosure() {
+        DoubleRange infinite = DoubleRange.all();
+        DoubleRange finite = DoubleRange.openClosed(3, 6);
+
+        assertThat(infinite.encloses(finite)).as("infinity encloses any range").isTrue();
+        assertThat(finite.encloses(infinite)).as("finite range can not enclose infinite range").isFalse();
+    }
+}

--- a/src/test/java/com/github/javachat/doublerange/DoubleRangeIntersectionTest.java
+++ b/src/test/java/com/github/javachat/doublerange/DoubleRangeIntersectionTest.java
@@ -1,0 +1,62 @@
+package com.github.javachat.doublerange;
+
+import com.github.javachat.common.BoundType;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.shouldHaveThrown;
+
+public class DoubleRangeIntersectionTest {
+    @Test
+    public void testIntersectionWithUnconnectedRanges() {
+        DoubleRange lower = DoubleRange.openClosed(0, 1);
+        DoubleRange higher = DoubleRange.openClosed(2, 3);
+        try {
+            lower.intersection(higher);
+            shouldHaveThrown(IllegalArgumentException.class);
+        } catch (IllegalArgumentException e) {
+            String msg = String.format(DoubleRange.NO_CONNECTION, lower, higher);
+            assertThat(e).hasMessage(msg);
+        }
+    }
+
+    @Test
+    public void testIntersectionNonEmpty() {
+        DoubleRange lower = DoubleRange.closed(1, 5);
+        DoubleRange higher = DoubleRange.open(3, 7);
+
+        DoubleRange intersection = lower.intersection(higher);
+        assertThat(intersection).isNotNull();
+        assertThat(intersection.isEmpty()).as("Intersection (3..5] is not empty").isFalse();
+        assertThat(intersection.lowerEndpoint()).as("lower bound").isEqualTo(3);
+        assertThat(intersection.lowerBoundType()).as("lower bound type should be open " +
+                "(as the lower bound of the 'bigger' range is open").isEqualTo(BoundType.OPEN);
+        assertThat(intersection.upperEndpoint()).as("higher bound").isEqualTo(5);
+        assertThat(intersection.upperBoundType()).as("higher bound should be closed " +
+                "(as the upper bound of the 'smaller' range is closed)").isEqualTo(BoundType.CLOSED);
+    }
+
+    @Test
+    public void testIntersectionEmpty() {
+        DoubleRange lower = DoubleRange.closedOpen(1, 5);
+        DoubleRange higher = DoubleRange.closedOpen(5, 7);
+
+        DoubleRange intersection = lower.intersection(higher);
+        assertThat(intersection.lowerEndpoint()).as("lower bound").isEqualTo(5);
+        assertThat(intersection.lowerBoundType()).as("lower bound type should be closed " +
+                "(lower boundary does not contain value)").isEqualTo(BoundType.CLOSED);
+        assertThat(intersection.upperEndpoint()).as("upper bound").isEqualTo(5);
+        assertThat(intersection.upperBoundType()).as("upper bound type should be open " +
+                "(upper boundary does contain value)").isEqualTo(BoundType.OPEN);
+        assertThat(intersection.isEmpty()).as("Intersection [5..5) should be empty").isTrue();
+    }
+
+    @Test
+    public void testInfiniteIntersection() {
+        DoubleRange infinite = DoubleRange.all();
+        DoubleRange finite = DoubleRange.closedOpen(5, 7);
+
+        DoubleRange intersection = infinite.intersection(finite);
+        assertThat(intersection).isEqualTo(finite);
+    }
+}

--- a/src/test/java/com/github/javachat/doublerange/DoubleRangeObjectMethodsTest.java
+++ b/src/test/java/com/github/javachat/doublerange/DoubleRangeObjectMethodsTest.java
@@ -1,0 +1,36 @@
+package com.github.javachat.doublerange;
+
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DoubleRangeObjectMethodsTest {
+    @Test
+    public void testFunctionalEquality() {
+        assertThat(DoubleRange.open(0, 1)).isEqualTo(DoubleRange.open(0, 1));
+        assertThat(DoubleRange.open(0, 1)).isNotEqualTo(DoubleRange.open(1, 2));
+        assertThat(DoubleRange.open(0, 1)).isNotEqualTo(DoubleRange.openClosed(0, 1));
+        assertThat(DoubleRange.open(0, 1)).isNotEqualTo(DoubleRange.closedOpen(0, 1));
+        assertThat(DoubleRange.open(0, 1)).isNotEqualTo(DoubleRange.closed(0, 1));
+    }
+
+    @Test
+    public void testEqualToContract() {
+        final DoubleRange range = DoubleRange.closed(0, 10);
+        assertThat(range.equals(null)).as("null detection").isFalse();
+        assertThat(range.equals("")).as("different type").isFalse();
+        assertThat(range.equals(range)).as("reflexive").isTrue();
+    }
+
+
+    @Test
+    public void testHashCode() {
+        final DoubleRange range = DoubleRange.closed(0, 10);
+        final DoubleRange sameRange = DoubleRange.closed(0, 10);
+        final DoubleRange otherRange = DoubleRange.closed(3, 6);
+
+        assertThat(range.hashCode()).as("identity").isEqualTo(range.hashCode());
+        assertThat(range.hashCode()).as("equal objects").isEqualTo(sameRange.hashCode());
+        assertThat(range.hashCode()).as("different object").isNotEqualTo(otherRange.hashCode());
+    }
+}

--- a/src/test/java/com/github/javachat/doublerange/DoubleRangeSpanTest.java
+++ b/src/test/java/com/github/javachat/doublerange/DoubleRangeSpanTest.java
@@ -1,0 +1,46 @@
+package com.github.javachat.doublerange;
+
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DoubleRangeSpanTest {
+    @Test
+    public void testEnclosedRangeSpan() {
+        DoubleRange outer = DoubleRange.open(0, 10);
+        DoubleRange inner = DoubleRange.open(3, 6);
+
+        DoubleRange spanningRange = outer.span(inner);
+        assertThat(spanningRange).isEqualTo(outer);
+    }
+
+    @Test
+    public void testUnconnectedRanges() {
+        DoubleRange lower = DoubleRange.closed(1, 3);
+        DoubleRange higher = DoubleRange.open(5, 7);
+
+        DoubleRange spanningRange = lower.span(higher);
+        assertThat(spanningRange).isEqualTo(DoubleRange.closedOpen(1, 7));
+    }
+
+    @Test
+    public void testConnectedRanges() {
+        DoubleRange lower = DoubleRange.closed(1, 5);
+        DoubleRange higher = DoubleRange.open(3, 7);
+
+        DoubleRange spanningRange = lower.span(higher);
+        assertThat(spanningRange).isEqualTo(DoubleRange.closedOpen(1, 7));
+    }
+
+    @Test
+    public void spanInfinity() {
+        DoubleRange infinite = DoubleRange.all();
+        DoubleRange finite = DoubleRange.open(3, 7);
+
+        DoubleRange spanningRange = infinite.span(finite);
+        assertThat(spanningRange).isEqualTo(infinite);
+
+        DoubleRange inverseSpan = finite.span(infinite);
+        assertThat(inverseSpan).isEqualTo(infinite);
+    }
+}

--- a/src/test/java/com/github/javachat/doublerange/DoubleRangeToStringTest.java
+++ b/src/test/java/com/github/javachat/doublerange/DoubleRangeToStringTest.java
@@ -1,0 +1,35 @@
+package com.github.javachat.doublerange;
+
+import com.github.javachat.common.BoundType;
+import org.assertj.core.api.Assertions;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+public class DoubleRangeToStringTest {
+    @Test
+    public void testOpenRange() {
+        DoubleRange range = new DoubleRange(1, BoundType.OPEN, 2, BoundType.OPEN);
+        assertThat(range.toString()).isEqualTo("(1.0..2.0)");
+    }
+
+    @Test
+    public void testClosedRange() {
+        DoubleRange range = new DoubleRange(1, BoundType.CLOSED, 2, BoundType.CLOSED);
+        assertThat(range.toString()).isEqualTo("[1.0..2.0]");
+    }
+
+    @Test
+    public void testHighPrecisionNumbers() {
+        DoubleRange range = new DoubleRange(Math.E, BoundType.CLOSED, Math.PI, BoundType.CLOSED);
+        assertThat(range.toString()).isEqualTo("[2.718282..3.141593]");
+    }
+
+    @Test
+    public void testInfinities() {
+        DoubleRange range = new DoubleRange(Double.NEGATIVE_INFINITY, BoundType.OPEN,
+                Double.POSITIVE_INFINITY, BoundType.OPEN);
+        assertThat(range.toString()).isEqualTo("(-Infinity..Infinity)");
+    }
+}


### PR DESCRIPTION
Using already existing code and Guava's [Range](http://google.github.io/guava/releases/19.0/api/docs/com/google/common/collect/Range.html#open%28C, C%29) documentation as a guideline, I have implemented the double version of the Range interface.

Code style is the default IntelliJ one, I'm happy to reformat my code using your formatter if you could link me to your settings.
